### PR TITLE
Laget en note

### DIFF
--- a/notebooks/Funksjoner i klargjøring/Håndtere dubletter_Python.ipynb
+++ b/notebooks/Funksjoner i klargjøring/Håndtere dubletter_Python.ipynb
@@ -1,0 +1,89 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Eksempler\n",
+    "<font size=2>Vi tar utgangspunkt i datasettet med landenes innbyggertall.\n",
+    "<ol>\n",
+    "<li>Lese inn og vise dataframe\n",
+    "<li>Sortere dataframe etter variabel\n",
+    "<li>Telle opp antall duplikater i form av identiske rader i dataframen og vise i liste\n",
+    "<li>Telle opp anntall duplikater i en variabel\n",
+    "<li>ny dataframe hvor duplikater på land er fjernet (dvs det skal gjenstå en rad pr land)- Fjerne dubletter, beholde en rad basert på et gitt kriterie\n",
+    "<li>Lage ny dataframe hvor duplikater på land er fjernet. Den som gjenstår skal være den rad med høyest innbyggerantall\n",
+    "<li>Ta ut de rader som har to eller flere forekomster på samme land i egen dataframe\n",
+    "<li>Telle opp antall og skrive ut/printe hvor mange rader som er identiske (duplikat på alle dvs variablene er identiske)\n",
+    "<li>Lage ny dataframe hvor rader som er identiske fjernet (dvs det skal gjenstå en rad) (edited)\n",
+    "</ol>\n",
+    "</font>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Importerer biblioteker"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dapla as dp\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1. Lese inn og vise dataframe \n",
+    "<font size=2>Lese inn dataframe: <code><i>navn_dataframe</i>.read_pandas(\"/felles/veiledning\")</code>\n",
+    "Vise dataframe: <code><i>navn_dataframe</i>.show()</code>\n",
+    "</font>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Read path into pandas dataframe \n",
+    "dp.read_pandas('/felles/veiledning/python/eksempler/purchases')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Har laget utkast til  note på/om dubletthåndtering i Python med pandas.
Kobler areal og innbyggerantall på Land (det kunne like gjerne vært landkode - egentlig mer naturlig. Men uansett  i og med at variabel Landkode ligger på begge datasettene, så vil den bli liggende to ganger (Landkode_x og Landkode y) på det sammenkoblede datasettet. Dette er kjent problemstilling. Jeg bør droppe landkode fra det ene datasettet før kobling. Da vil det ikke bli dobbelt opp.