### PR TITLE
Koble datasett i Phyton med Pandas

### DIFF
--- a/notebooks/Funksjoner i klargjøring/Koble datasett i Python.ipynb
+++ b/notebooks/Funksjoner i klargjøring/Koble datasett i Python.ipynb
@@ -124,7 +124,7 @@
     "\n",
     "Land og landkode er konblingsnøkler, så de kan være like.\n",
     "\n",
-    "For å endre navn på en kolonne (variabel) i datasettet, brukes pyspark-funksjonen <code><i>dataframe</i>.rename</code></font>"
+    "For å endre navn på en kolonne (variabel) i datasettet, brukes metoden <code><i>dataframe</i>.rename</code></font>"
    ]
   },
   {
@@ -175,7 +175,9 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "df_areal_innbyggerantall_union"
+   ]
   },
   {
    "cell_type": "code",

--- a/notebooks/Funksjoner i klargjøring/Koble datasett i Python.ipynb
+++ b/notebooks/Funksjoner i klargjøring/Koble datasett i Python.ipynb
@@ -83,7 +83,7 @@
    "metadata": {},
    "source": [
     "### Kontrollere om det er konflikter i variabelnavnene (kolonnene)\n",
-    "<font size=2>Når to datasett skal kobles, er det viktig at kolonnene, som ikke er koblingsnøkkel har forskjellige navn. Dette kan løses på forskjellige måter. I dette eksemplet sjekker vi først hva kolonnene heter og deretter endrere vi kolonnennavnene for å unngå konflikt. For å sjekke kolonnenavn kan vi bruke pyspark-funksjonen for å skrive ut <i>skjemaet</i> til datasettet: <code><i>dataframe</i>.info()</code>\n",
+    "<font size=2>Når to datasett skal kobles, er det viktig at kolonnene, som ikke er koblingsnøkkel har forskjellige navn. Dette kan løses på forskjellige måter. I dette eksemplet sjekker vi først hva kolonnene heter og deretter endrere vi kolonnennavnene for å unngå konflikt. For å sjekke kolonnenavn kan vi bruke metoden for å skrive ut <i>skjemaet</i> til datasettet: <code><i>dataframe</i>.info()</code>\n",
     "</font>"
    ]
   },

--- a/notebooks/Funksjoner i klargjøring/Koble datasett i Python.ipynb
+++ b/notebooks/Funksjoner i klargjøring/Koble datasett i Python.ipynb
@@ -1,0 +1,209 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Koble data i Python med bruk av Pandas bibliotek\n",
+    "<font size=2>Når du skal koble sammen to datasett ved hjelp av koblingsnøkkel eller identifiseringsvariabler slik at datasettet består av variablene fra begge datasett, kan du bruke merge metoden:\n",
+    "<code>pandas.merge</code>: <i>Merge DataFrame objects by performing a database-style join operation by columns or indexes..</i> ([https://pandas.pydata.org/pandas-docs/version/0.23.4/generated/pandas.merge.html](https://spark.apache.org/docs/latest/api/R/join.html))\n",
+    "\n",
+    "Eksemplene under kobler sammen datasettene <code>areal</code> og <code>innbyggerantall</code>. Enhetene og nøkkelen er <i>Land</i>. \n",
+    "- Det første eksempelet kobler land som er med i begge settene. Det nye datasettet inneholder snittet av land (koblingsmetoden 'inner').\n",
+    "- Det andre eksempelet kobler alle landene sammen. Det nye datasettet inneholder unionen av land (koblingsmetode = 'outer').\n",
+    "</font>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Innhenter verktøy fra bibliotek\n",
+    "Daplas Python pakke (dapla) og biblioteket pandas importeres."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dapla as dp\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Vis tilgjengelige datasett\n",
+    "Kjører metoden show for å få oversikt over parquet datasett som skal være utgangspunkt for koblinger.\n",
+    "Oversikten blir lest inn i egen dataframe - df_datasets. Aktuelt lagringsområde blir lagt inn som parameter (string objekt som vi definerer selv) INNDATA_PATH."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "INNDATA_PATH = '/felles/veiledning/pyspark/eksempler/'\n",
+    "df_datasets = dp.show(INNDATA_PATH)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_datasets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Hente eksempeldata (kode)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_areal           = dp.read_pandas(INNDATA_PATH+'areal')\n",
+    "df_bnp             = dp.read_pandas(INNDATA_PATH+'bnp')\n",
+    "df_innbyggerantall = dp.read_pandas(INNDATA_PATH+'innbyggerantall/2020')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Kontrollere om det er konflikter i variabelnavnene (kolonnene)\n",
+    "<font size=2>Når to datasett skal kobles, er det viktig at kolonnene, som ikke er koblingsnøkkel har forskjellige navn. Dette kan løses på forskjellige måter. I dette eksemplet sjekker vi først hva kolonnene heter og deretter endrere vi kolonnennavnene for å unngå konflikt. For å sjekke kolonnenavn kan vi bruke pyspark-funksjonen for å skrive ut <i>skjemaet</i> til datasettet: <code><i>dataframe</i>.info()</code>\n",
+    "</font>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Viser skjemaet til df_areal og df_innbyggerantall (kode)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_areal.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_innbyggerantall.info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Endre kolonnennavn (variabelnavn)\n",
+    "<font size=2>I eksempelet med datasettene <code>df_areal</code> og <code>df_innbyggerantall</code> ser vi at følgende variabler (kolonnenavn) som bør endres:\n",
+    "- <code>df_areal.Årstall</code> er ikke i konflikt med <code>df_innbyggerantall.År</code>, men kan gjerne endres til forståelige navn, som f.eks. <code>df_areal.Registrert_areal</code> og <code>df_innbyggerantall.Registrert_innbyggerantall</code>\n",
+    "- <code>df_areal.Kilde</code> --> <code>df_areal.Kilde_areal</code>\n",
+    "- <code>df_innbyggerantall.Kilde</code> --> <code>df_innbyggerantall.Kilde_innbyggerantall</code>\n",
+    "\n",
+    "Land og landkode er konblingsnøkler, så de kan være like.\n",
+    "\n",
+    "For å endre navn på en kolonne (variabel) i datasettet, brukes pyspark-funksjonen <code><i>dataframe</i>.rename</code></font>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_areal = df_areal.rename(columns = {'Årstall': 'Registrert_areal', 'Kilde': 'Kilde_areal'}, inplace = False)\n",
+    "df_innbyggerantall = df_innbyggerantall.rename(columns = {'År': 'Registrert_innbyggerantall', 'Kilde': 'Kilde_innbyggerantall'}, inplace = False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Koble land som har areal og innbyggertall (snitt = 'inner') (kode)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_areal_innbyggerantall = pd.merge(left=df_areal, right=df_innbyggerantall, left_on='Land', right_on='Land', how='inner')\n",
+    "df_areal_innbyggerantall"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Koble alle landene sammen (union = 'outer') (kode)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_areal_innbyggerantall_union = pd.merge(left=df_areal, right=df_innbyggerantall, left_on='Land', right_on='Land', how='outer')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Pyspark (local)",
+   "language": "python",
+   "name": "pyspark_local"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Har laget utkast til note på/om koblinger i Python med pandas.
Kobler areal og innbyggerantall på Land (det kunne like gjerne vært landkode - egentlig mer naturlig. Men uansett i og med at variabel Landkode ligger på begge datasettene, så vil den bli liggende to ganger (Landkode_x og Landkode y) på det sammenkoblede datasettet. Dette er kjent problemstilling. Jeg bør droppe landkode fra det ene datasettet før kobling. Da vil det ikke bli dobbelt opp.
