### PR TITLE
Link to python package management doc

### DIFF
--- a/notebooks/Innhold i veilederen.ipynb
+++ b/notebooks/Innhold i veilederen.ipynb
@@ -54,6 +54,8 @@
     "Eksempler på funksjoner for å etablere klargjøringsgrunnlag ved bruk av Pyspark; hvordan koble datasett, håndtere dubletter, gjøre en logisk imputering, pivotere, sette sammen datasett og noen enkle beregninger.\n",
     "##### [Fellesfunksjoner (SSB Spark tools)](Fellesfunksjoner%20(SSB%20Spark%20tools)/Fellesfunksjoner%20(SSB%20Spark%20tools).ipynb)\n",
     "I biblioteket SSB Spark tools finnes det PySpark-funksjoner som er laget til bruk i statistikkproduksjonen på SSB. Her vises det hvordan man kan se hvilke funksjoner som ligger i SSB Spark tools og et eksempel på hvordan disse funksjonene kan brukes. \n",
+    "##### [Installere andre Python pakker](https://github.com/statisticsnorway/dapla-project/blob/master/doc/jupyter-dependency-management.md)\n",
+    "Noen ganger vil man installere andre Python biblioteker/pakker en de som er installert fra før, eller bruke en eldre/nyere versjon av en gitt pakke. I Jupyterlab kan du bruke forskjellige pakker for hvert prosjekt, ved å bruke kommandolinjeverktøy. \n",
     "##### [Metadata og kodelister](Metadata%20og%20kodelister/Metadata%20og%20kodelister.ipynb)\n",
     "Metadata og kodelister er viktig for statistikkproduksjonen. Her får du blant annet eksempler på hvordan du kan laste inn og sjekke kodelister fra KLASS.\n",
     "##### [Statistikkproduksjon](Statistikkproduksjon/mod_statistikkproduksjon.ipynb)\n",


### PR DESCRIPTION
I have implemented a way for SSBs JupyterLab users to install different Python packages for each JupyterLab project (on Dapla).

The documentation for this functionality has been written in a different repository. I wish to link to that documentation somewhere inside this guide.

The functionality described in this documentation has been properly released in production.